### PR TITLE
feat: add error handling and permission checks for message sending

### DIFF
--- a/commands/interaction_types/command.js
+++ b/commands/interaction_types/command.js
@@ -7,7 +7,11 @@ const controller = {};
 controller.router = async (interaction) => {
   try {
     if (interaction.commandName === "info") {
-      await interaction.reply({ embeds: [genericCommands.getInfoContent()] });
+      await interaction
+        .reply({ embeds: [genericCommands.getInfoContent()] })
+        .catch((error) => {
+          logger.error("Error replying to info command:", error);
+        });
     } else if (
       interaction.commandName === "ask" ||
       interaction.commandName === "support"
@@ -17,17 +21,22 @@ controller.router = async (interaction) => {
       if (await controller.hasPermissions(interaction)) {
         await tensorCommands.addQuestion(interaction);
       } else {
-        await interaction.reply(
-          "You do not have permissions to use this command",
-        );
+        await interaction
+          .reply("You do not have permissions to use this command")
+          .catch((error) => {
+            logger.error("Error replying to train command:", error);
+          });
       }
     } else if (interaction.commandName === "donate") {
-      await interaction.reply("https://ko-fi.com/deeme");
+      await interaction.reply("https://ko-fi.com/deeme").catch((error) => {
+        logger.error("Error replying to donate command:", error);
+      });
     } else {
-      await interaction.reply("I don't know this command");
+      await interaction.reply("I don't know this command").catch((error) => {
+        logger.error("Error replying to unknown command:", error);
+      });
     }
   } catch (e) {
-    console.log(e);
     logger.error(e);
   }
 };

--- a/commands/interaction_types/modal.js
+++ b/commands/interaction_types/modal.js
@@ -21,34 +21,40 @@ controller.router = async (interaction) => {
       await tensorCommands.trainFromUsers(interaction);
     }
   } catch (e) {
-    console.log(e);
     logger.error(e);
   }
 };
 
 controller.showTrainModal = async (interaction, customId = "trainmodal") => {
-  const modal = new ModalBuilder()
-    .setCustomId(customId)
-    .setTitle("Train Modal");
+  try {
+    const modal = new ModalBuilder()
+      .setCustomId(customId)
+      .setTitle("Train Modal");
 
-  const questionInput = new TextInputBuilder()
-    .setCustomId("questionInput")
-    .setLabel("Question")
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true);
+    const questionInput = new TextInputBuilder()
+      .setCustomId("questionInput")
+      .setLabel("Question")
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
 
-  const answerInput = new TextInputBuilder()
-    .setCustomId("answerInput")
-    .setLabel("Answer")
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(true);
+    const answerInput = new TextInputBuilder()
+      .setCustomId("answerInput")
+      .setLabel("Answer")
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(true);
 
-  const firstActionRow = new ActionRowBuilder().addComponents(questionInput);
-  const secondActionRow = new ActionRowBuilder().addComponents(answerInput);
+    const firstActionRow = new ActionRowBuilder().addComponents(questionInput);
+    const secondActionRow = new ActionRowBuilder().addComponents(answerInput);
 
-  modal.addComponents(firstActionRow, secondActionRow);
+    modal.addComponents(firstActionRow, secondActionRow);
 
-  await interaction.showModal(modal);
+    await interaction.showModal(modal).catch((error) => {
+      logger.error("Error showing modal:", error);
+      throw error;
+    });
+  } catch (error) {
+    logger.error("Error in showTrainModal:", error);
+  }
 };
 
 controller.hasPermissions = async (interaction) => {

--- a/helpers/others.js
+++ b/helpers/others.js
@@ -8,9 +8,33 @@ controller.sendChannelMessage = (channel, text) => {
 };
 
 controller.sendChannelData = (channel, data) => {
+  if (!controller.canSendMessages(channel)) {
+    logger.warn(`No permissions to send message in channel: ${channel.id}`);
+    return;
+  }
+
   channel.send(data).catch((error) => {
     logger.error(error);
   });
+};
+
+controller.canSendMessages = (channel) => {
+  try {
+    if (!channel || !channel.guild) {
+      return false;
+    }
+
+    const botMember = channel.guild.members.me;
+    if (!botMember) {
+      return false;
+    }
+
+    const permissions = channel.permissionsFor(botMember);
+    return permissions?.has("SendMessages");
+  } catch (error) {
+    logger.error("Error checking permissions:", error);
+    return false;
+  }
 };
 
 controller.apiRequest = async (options) => {

--- a/index.js
+++ b/index.js
@@ -62,9 +62,13 @@ client.on("interactionCreate", async (interaction) => {
       await buttonController.router(interaction);
     } else if (interaction.type === InteractionType.ApplicationCommand) {
       if (interaction.commandName === "help") {
-        await interaction.reply(
-          genericCommands.getHelpContent(slashCommandsRegister.getCommands()),
-        );
+        await interaction
+          .reply(
+            genericCommands.getHelpContent(slashCommandsRegister.getCommands()),
+          )
+          .catch((error) => {
+            logger.error("Error replying to help command:", error);
+          });
       } else if (interaction.commandName === "trainm") {
         await modalController.router(interaction, client);
       } else {
@@ -74,7 +78,7 @@ client.on("interactionCreate", async (interaction) => {
       await modalController.router(interaction, client);
     }
   } catch (e) {
-    logger.error(e);
+    logger.error("Error in interactionCreate:", e);
   }
 });
 
@@ -122,10 +126,14 @@ const messageEvent = async (msg, forceResponse = false) => {
     const response = await tensorCommands.getAnAnswer(msg.content);
     if (response) {
       const row = new ActionRowBuilder().addComponents(editButton);
-      msg.reply({
-        content: response,
-        components: [row],
-      });
+      msg
+        .reply({
+          content: response,
+          components: [row],
+        })
+        .catch((error) => {
+          logger.error("Error sending reply:", error);
+        });
     }
   } catch (e) {
     logger.error(e);


### PR DESCRIPTION
- Implement canSendMessages helper to check bot permissions
- Add comprehensive error handling for interaction replies
- Improve logging with more descriptive error messages
- Add permission checks before sending messages in messageEvent
- Wrap modal operations in try-catch blocks
- Enhance error handling in tensor commands operations

## Summary by Sourcery

Add robust error handling around Discord interactions and enforce permission checks for message sending with improved logging and mention validation

New Features:
- Introduce canSendMessages helper for permission validation
- Add permission check in channel message sending and messageEvent

Enhancements:
- Wrap interaction.deferReply, reply, editReply, and showModal calls in try-catch blocks with descriptive logging
- Reject questions and answers containing @ mentions in tensor commands